### PR TITLE
use lazy routing correctly

### DIFF
--- a/src/routes/admin/player/components/player-index.component.js
+++ b/src/routes/admin/player/components/player-index.component.js
@@ -4,6 +4,7 @@ import holes from '../../../../data/holes'
 import PlayerList from './player-list.component'
 import style from './player.styles'
 import Helmet from 'react-helmet/es/Helmet'
+import { Link } from 'react-router'
 
 // noinspection JSUnusedGlobalSymbols
 const PlayerIndex = () => (
@@ -20,7 +21,7 @@ const PlayerIndex = () => (
         <div className='col-auto'>
           <dl>
             <dt>大会名</dt>
-            <dd><a href='/pgateaching_201709'>第19回 PGAティーチングプロ選手権大会</a></dd>
+            <dd><Link to='/pgateaching_201709'>第19回 PGAティーチングプロ選手権大会</Link></dd>
             <dt>ゴルフ場</dt>
             <dd>登別カントリー倶楽部</dd>
             <dt>開催日</dt>

--- a/src/routes/leadersboard/index.js
+++ b/src/routes/leadersboard/index.js
@@ -10,6 +10,6 @@ export default (store) => ({
       injectReducer(store, {key: 'leadersBoard', reducer})
       fetchPlayers()(store.dispatch)
       cb(null, PlayerIndex)
-    }, 'players')
+    }, 'pgateaching_201709')
   }
 })


### PR DESCRIPTION
Note:

Angular router has an ability like below.

1. Open page A
  * load main.js
  * load js for page A
  * async load js for page B
  * async load js for page C

But I don't know how to do it in React.

So, current implementation is ...

1. Open page A
  * load main.js
  * load js for page A
2. Move to page B
  * load js for page B
3. Move to page C
  * load js for page C
